### PR TITLE
fix: configura variável de ambiente BREVO_API_KEY

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -10,6 +10,7 @@ class __Settings(BaseSettings):
     JWT_SECRETE_KEY: str
     PASSWORD_HASH_ALGORITHM: str
     JWT_EXPIRE_MINUTES: int
+    BREVO_API_KEY: str
 
     model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8')
 


### PR DESCRIPTION
## Descrição de mudança
Este PR adicionar o campo `BREVO_API_KEY` ao `settings.py`

Esse fix fará com que a aplicação funcione no ambiente de produção, que atualmente está recebendo este erro:
![image](https://github.com/user-attachments/assets/aafb29c8-24be-41cb-aae5-44342ec39e44)

## Problemas resolvidos por este PR
- [x] Aplicação deixará de retornar erro pela variável BREVO_API_KEY não ter sido configurada

## Mais informações
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Novos Recursos**
  - Incluída uma nova opção de configuração para integrar a chave da API do serviço Brevo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->